### PR TITLE
Fixes for trajectory generation

### DIFF
--- a/src/main/native/cpp/pathplanner/lib/GeometryUtil.cpp
+++ b/src/main/native/cpp/pathplanner/lib/GeometryUtil.cpp
@@ -6,6 +6,10 @@ units::second_t GeometryUtil::unitLerp(units::second_t startVal, units::second_t
    return startVal + (endVal - startVal) * t;
 }
 
+units::meters_per_second_t GeometryUtil::unitLerp(units::meters_per_second_t startVal, units::meters_per_second_t endVal, double t) {
+   return startVal + (endVal - startVal) * t;
+}
+
 units::meters_per_second_squared_t GeometryUtil::unitLerp(units::meters_per_second_squared_t startVal, units::meters_per_second_squared_t endVal, double t) {
    return startVal + (endVal - startVal) * t;
 }

--- a/src/main/native/include/pathplanner/lib/GeometryUtil.h
+++ b/src/main/native/include/pathplanner/lib/GeometryUtil.h
@@ -16,6 +16,7 @@ namespace pathplanner {
     class GeometryUtil {
     public:
         static units::second_t unitLerp(units::second_t startVal, units::second_t endVal, double t);
+        static units::meters_per_second_t unitLerp(units::meters_per_second_t startVal, units::meters_per_second_t endVal, double t);
         static units::meters_per_second_squared_t unitLerp(units::meters_per_second_squared_t startVal, units::meters_per_second_squared_t endVal, double t);
         static units::radians_per_second_t unitLerp(units::radians_per_second_t startVal, units::radians_per_second_t endVal, double t);
         static units::radians_per_second_squared_t unitLerp(units::radians_per_second_squared_t startVal, units::radians_per_second_squared_t endVal, double t);

--- a/src/main/native/include/pathplanner/lib/PathPlannerTrajectory.h
+++ b/src/main/native/include/pathplanner/lib/PathPlannerTrajectory.h
@@ -56,7 +56,7 @@ namespace pathplanner{
         private:
             std::vector<PathPlannerState> states;
             std::vector<PathPlannerState> joinSplines(std::vector<Waypoint> pathPoints, units::meters_per_second_t maxVel, double step);
-            void calculateMaxVel(std::vector<PathPlannerState> *states, units::meters_per_second_t maxVel, units::meters_per_second_squared_t maxAccel);
+            void calculateMaxVel(std::vector<PathPlannerState> *states, units::meters_per_second_t maxVel, units::meters_per_second_squared_t maxAccel, bool reversed);
             void calculateVelocity(std::vector<PathPlannerState> *states, std::vector<Waypoint> pathPoints, units::meters_per_second_squared_t maxAccel);
             void recalculateValues(std::vector<PathPlannerState> *states, bool reversed);
             units::meter_t calculateRadius(PathPlannerState s0, PathPlannerState s1, PathPlannerState s2);


### PR DESCRIPTION
I encountered two issues when using the trajectories generated by PathPlanner on a differential drive robot:

1) The curvature is always positive. In trajectories that come out of PathWeaver, the curvature is negative when the robot is turning toward the right and positive when it is turning toward the left (following the WPILib axis conventions). If the Ramsete controller is disabled, this is easily seen by the robot turning toward the left when it should turn toward the right (the Ramsete controller fights the incorrect turn and makes the robot do the "right" thing, though it does not end up in the right place because of fighting the wrong turn). The fix is to use the cross product and the right hand rule for the three consecutive points in the path to determine if the curvature should be negated. Note that a positive curvature is required if the path the robot is following curves to the left side of the robot and negative if the path curves to the right side of the robot, regardless of the direction the robot is moving along the path.

2) The interpolation of the velocity does not use a lerp like the other interpolations. This results in a velocity that always increases between waypoints. During positive accelerations, this is not very noticeable. However, during negative accelerations, the stair-step effect this produces results in the robot moving in a very jerky manner (as it speeds up, slows down, speeds up, slows down, etc. across each virtual waypoint that is generated between the actual waypoints). Using the existing lerp to interpolate the velocity solves this problem and results in a very smooth velocity profile.

The Java version has been tested on a robot (we are a Java team). The C++ version follows the same algorithm, and builds, so it _should_ work but it is not tested.