### PR TITLE
Load trajectories from string.

### DIFF
--- a/src/main/java/com/pathplanner/lib/PathPlanner.java
+++ b/src/main/java/com/pathplanner/lib/PathPlanner.java
@@ -33,7 +33,17 @@ public class PathPlanner {
 
             String fileContent = fileContentBuilder.toString();
 
-            JSONObject json = (JSONObject) new JSONParser().parse(fileContent);
+            return loadPathFromString(fileContent, maxVel, maxAccel, reversed);
+        }catch (Exception e){
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    public static PathPlannerTrajectory loadPathFromString(String content, double maxVel, double maxAccel, boolean reversed) {
+        try
+        {
+            JSONObject json = (JSONObject) new JSONParser().parse(content);
             JSONArray jsonWaypoints = (JSONArray) json.get("waypoints");
 
             ArrayList<PathPlannerTrajectory.Waypoint> waypoints = new ArrayList<>();
@@ -104,6 +114,10 @@ public class PathPlanner {
      */
     public static PathPlannerTrajectory loadPath(String name, double maxVel, double maxAccel){
         return loadPath(name, maxVel, maxAccel, false);
+    }
+
+    public static PathPlannerTrajectory loadPathFromString(String content, double maxVel, double maxAccel){
+        return loadPathFromString(content, maxVel, maxAccel, false);
     }
 
     private static PathPlannerTrajectory joinPaths(ArrayList<PathPlannerTrajectory> paths){

--- a/src/main/native/cpp/pathplanner/lib/PathPlanner.cpp
+++ b/src/main/native/cpp/pathplanner/lib/PathPlanner.cpp
@@ -3,7 +3,6 @@
 #include <frc/geometry/Rotation2d.h>
 #include <frc/Filesystem.h>
 #include <wpi/SmallString.h>
-#include <wpi/raw_istream.h>
 #include <wpi/json.h>
 #include <units/length.h>
 #include <units/angle.h>
@@ -26,8 +25,18 @@ PathPlannerTrajectory PathPlanner::loadPath(std::string name, units::meters_per_
         throw std::runtime_error(("Cannot open file: " + filePath));
     }
 
+    return loadPathFromIstream(input, maxVel, maxAccel, reversed);
+}
+
+PathPlannerTrajectory PathPlanner::loadPathFromString(std::string value, units::meters_per_second_t maxVel, units::meters_per_second_squared_t maxAccel, bool reversed){
+    wpi::raw_mem_istream istream(value);
+
+    return loadPathFromIstream(istream, maxVel, maxAccel, reversed);
+}
+
+PathPlannerTrajectory PathPlanner::loadPathFromIstream(wpi::raw_istream &value, units::meters_per_second_t maxVel, units::meters_per_second_squared_t maxAccel, bool reversed){
     wpi::json json;
-    input >> json;
+    value >> json;
 
     std::vector<PathPlannerTrajectory::Waypoint> waypoints;
     for (wpi::json::reference waypoint : json.at("waypoints")){

--- a/src/main/native/include/pathplanner/lib/PathPlanner.h
+++ b/src/main/native/include/pathplanner/lib/PathPlanner.h
@@ -3,6 +3,7 @@
 #include "pathplanner/lib/PathPlannerTrajectory.h"
 #include <units/velocity.h>
 #include <units/acceleration.h>
+#include <wpi/raw_istream.h>
 #include <string>
 #include <vector>
 
@@ -13,11 +14,19 @@ namespace pathplanner{
 
             static pathplanner::PathPlannerTrajectory loadPath(std::string name, units::meters_per_second_t maxVel, units::meters_per_second_squared_t maxAccel, bool reversed);
 
+            static pathplanner::PathPlannerTrajectory loadPathFromString(std::string value, units::meters_per_second_t maxVel, units::meters_per_second_squared_t maxAccel, bool reversed);
+
             static pathplanner::PathPlannerTrajectory loadPath(std::string name, units::meters_per_second_t maxVel, units::meters_per_second_squared_t maxAccel){
                 return PathPlanner::loadPath(name, maxVel, maxAccel, false);
             }
 
+            static pathplanner::PathPlannerTrajectory loadPathFromString(std::string value, units::meters_per_second_t maxVel, units::meters_per_second_squared_t maxAccel){
+                return PathPlanner::loadPathFromString(value, maxVel, maxAccel, false);
+            }
+
         private:
+            static pathplanner::PathPlannerTrajectory loadPathFromIstream(wpi::raw_istream &istream, units::meters_per_second_t maxVel, units::meters_per_second_squared_t maxAccel, bool reversed);
+
             static pathplanner::PathPlannerTrajectory joinPaths(std::vector<pathplanner::PathPlannerTrajectory> paths);
     };
 }


### PR DESCRIPTION
Loading trajectories from strings is useful for building a desktop app to test and plot the trajectories generated by PathPlanner (bypassing the RoboRIO-specific deploy directory code and avoiding the need to mock it). These changes allow this to happen, while keeping the existing method for loading paths on a RoboRIO.

These changes were instrumental to identifying the issues in the trajectory generation (from https://github.com/mjansen4857/pathplannerlib/pull/3) and correcting them. As in the other pull request, the Java version has been tested and the C++ version _should_ work but it untested (other than knowing that it builds).