### PR TITLE
Negate curvature when driving in "reverse"

### DIFF
--- a/src/main/java/com/pathplanner/lib/PathPlannerTrajectory.java
+++ b/src/main/java/com/pathplanner/lib/PathPlannerTrajectory.java
@@ -189,7 +189,11 @@ public class PathPlannerTrajectory extends Trajectory {
             if(Double.isInfinite(now.curveRadius) || Double.isNaN(now.curveRadius) || now.curveRadius == 0){
                 now.curvatureRadPerMeter = 0;
             }else{
-                now.curvatureRadPerMeter = 1 / now.curveRadius;
+                var sign = 1.0;
+                if (reversed) {
+                    sign = -1.0;
+                }
+                now.curvatureRadPerMeter = sign / now.curveRadius;
             }
         }
     }

--- a/src/main/java/com/pathplanner/lib/PathPlannerTrajectory.java
+++ b/src/main/java/com/pathplanner/lib/PathPlannerTrajectory.java
@@ -189,11 +189,7 @@ public class PathPlannerTrajectory extends Trajectory {
             if(Double.isInfinite(now.curveRadius) || Double.isNaN(now.curveRadius) || now.curveRadius == 0){
                 now.curvatureRadPerMeter = 0;
             }else{
-                var sign = 1.0;
-                if (reversed) {
-                    sign = -1.0;
-                }
-                now.curvatureRadPerMeter = sign / now.curveRadius;
+                now.curvatureRadPerMeter = 1 / now.curveRadius;
             }
         }
     }

--- a/src/main/native/cpp/pathplanner/lib/PathPlannerTrajectory.cpp
+++ b/src/main/native/cpp/pathplanner/lib/PathPlannerTrajectory.cpp
@@ -195,7 +195,11 @@ void PathPlannerTrajectory::recalculateValues(std::vector<PathPlannerTrajectory:
         if(!GeometryUtil::isFinite(now->curveRadius) || GeometryUtil::isNaN(now->curveRadius) || now->curveRadius() == 0){
             now->curvature = units::curvature_t{0};
         }else{
-            now->curvature = units::curvature_t{1 / now->curveRadius()};
+            auto sign = 1.0;
+            if (reversed) {
+                sign = -1.0;
+            }
+            now->curvature = units::curvature_t{sign / now->curveRadius()};
         }
     }
 }

--- a/src/main/native/cpp/pathplanner/lib/PathPlannerTrajectory.cpp
+++ b/src/main/native/cpp/pathplanner/lib/PathPlannerTrajectory.cpp
@@ -106,7 +106,7 @@ void PathPlannerTrajectory::calculateMaxVel(std::vector<PathPlannerTrajectory::P
         if(!GeometryUtil::isFinite(radius) || GeometryUtil::isNaN(radius)){
             states->data()[i].velocity = units::math::min(maxVel, states->data()[i].velocity);
         }else{
-            states->data()[i].curveRadius = units::math::abs(radius);
+            states->data()[i].curveRadius = radius;
 
             units::meters_per_second_t maxVCurve = units::math::sqrt(maxAccel * radius);
 
@@ -195,11 +195,7 @@ void PathPlannerTrajectory::recalculateValues(std::vector<PathPlannerTrajectory:
         if(!GeometryUtil::isFinite(now->curveRadius) || GeometryUtil::isNaN(now->curveRadius) || now->curveRadius() == 0){
             now->curvature = units::curvature_t{0};
         }else{
-            auto sign = 1.0;
-            if (reversed) {
-                sign = -1.0;
-            }
-            now->curvature = units::curvature_t{sign / now->curveRadius()};
+            now->curvature = units::curvature_t{1 / now->curveRadius()};
         }
     }
 }


### PR DESCRIPTION
Hi, I think there's a bug in curvature's sign on "reversed" path segments.

Here's a plot w/ 4 graphs:
1. pose_dtheta - the measured change in angle over time from odometry
2. traj_dtheta - the measured change in angle over time from reference states in a trajectory
3. traj_vw - the calculated angular velocity of the trajectory over time - this is reference state velocity * curvature
4. Drive/cmd/vw - the calculated angular velocity command after considering pose error in a Ramsete controller

x axis is measure in seconds, y axis is radians / second.
![image](https://user-images.githubusercontent.com/1332080/164535646-d386b6cb-0026-4241-9cd8-157956eedb80.png)

The two I'd specifically highlight are traj_dtheta (lime green) and traj_vw (orange). They're negative of each other, which means a sign is flipped somewhere in between. 

I trust that the change in angle over time is more correct than reference state velocity * curvature, and velocity is most certainly correct as well, which leaves curvature to be the problem. After implementing this patch, I see the following results instead on my robot:
![image](https://user-images.githubusercontent.com/1332080/164536838-908c1a24-31d6-4782-b679-e3cfca97625a.png)

Much better.
